### PR TITLE
fix: make khelm fails on osx due to leading spaces in helm version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KUSTOMIZE_VERSION ?= 3.9.3
 
 REV := $(shell git rev-parse --short HEAD 2> /dev/null || echo 'unknown')
 VERSION ?= $(shell echo "$$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null || echo dev)-$(REV)" | sed 's/^v//')
-HELM_VERSION := $(shell grep k8s\.io/helm go.mod | sed -E -e 's/k8s\.io\/helm|\s+|\+.*//g' -e 's/^v//')
+HELM_VERSION := $(shell grep k8s\.io/helm go.mod | sed -E -e 's/k8s\.io\/helm|\s+|\+.*//g' -e 's/^v//' | cut -d " " -f2)
 GO_LDFLAGS := -X main.khelmVersion=$(VERSION) -X main.helmVersion=$(HELM_VERSION)
 BUILDTAGS ?= 
 


### PR DESCRIPTION
When go building the khelm binary, an ldflags string is concatenated and passed
as an argument to go build. Part of this string is a helm version, which is
extracted from go.mod. The extracted string contains a number of leading spaces,
which subsequently causes the go build to fail. The malformed command previously
looked something like:

    go build … -ldflags "… -X main.helmVersion=  v2.17.0"
                                               ^^- extra spaces