### PR TITLE
fix: file download race condition.

### DIFF
--- a/pkg/helm/locate.go
+++ b/pkg/helm/locate.go
@@ -112,6 +112,11 @@ func locateChart(ctx context.Context, cfg *config.LoaderConfig, repos repository
 			return
 		}
 		err = os.Rename(tmpDestDir, destDir)
+		if os.IsExist(err) {
+			// Ignore error if file was downloaded by another process concurrently.
+			// This fixes a race condition, see https://github.com/mgoltzsche/khelm/issues/36
+			err = os.RemoveAll(tmpDestDir)
+		}
 		err = errors.WithStack(err)
 	}()
 	select {

--- a/pkg/helm/repositories.go
+++ b/pkg/helm/repositories.go
@@ -404,6 +404,11 @@ func downloadIndexFile(ctx context.Context, entry *repo.Entry, cacheDir string, 
 			return
 		}
 		err = os.Rename(tmpIdxFileName, idxFile)
+		if os.IsExist(err) {
+			// Ignore error if file was downloaded by another process concurrently.
+			// This fixes a race condition, see https://github.com/mgoltzsche/khelm/issues/36
+			err = os.Remove(tmpIdxFileName)
+		}
 		err = errors.WithStack(err)
 	}()
 	select {


### PR DESCRIPTION
Ignore a file exists error when attempting to rename a downloaded file that was downloaded meanwhile by another process.

Closes #36