### PR TITLE
fix: file download race condition in v1

### DIFF
--- a/pkg/helm/locate.go
+++ b/pkg/helm/locate.go
@@ -108,6 +108,11 @@ func locateChart(ctx context.Context, cfg *config.LoaderConfig, repos repository
 			return
 		}
 		err = os.Rename(tmpDestDir, destDir)
+		if os.IsExist(err) {
+			// Ignore error if file was downloaded by another process concurrently.
+			// This fixes a race condition, see https://github.com/mgoltzsche/khelm/issues/36
+			err = os.RemoveAll(tmpDestDir)
+		}
 		err = errors.WithStack(err)
 	}()
 	select {

--- a/pkg/helm/repositories.go
+++ b/pkg/helm/repositories.go
@@ -450,6 +450,11 @@ func downloadIndexFile(ctx context.Context, entry *repo.Entry, cacheDir string, 
 			return
 		}
 		err = os.Rename(tmpIdxFileName, idxFile)
+		if os.IsExist(err) {
+			// Ignore error if file was downloaded by another process concurrently.
+			// This fixes a race condition, see https://github.com/mgoltzsche/khelm/issues/36
+			err = os.Remove(tmpIdxFileName)
+		}
 		err = errors.WithStack(err)
 	}()
 	select {


### PR DESCRIPTION
Ignore a file exists error when attempting to rename a downloaded file that was downloaded meanwhile by another process.

Relates to #36 