### PR TITLE
feat: simplify creation of declarative krm/kpt functions, align kpt config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 /example/**/charts
 /example/**/tmpcharts
 /example/kpt/*/output*
-/example/kpt/*/generated-*
+/example/kpt/*/generated*
 /example/kpt/**/requirements.lock
 /example/**/generated-manifest-without-secrets.yaml
-
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir /helm && chown root:nobody /helm && chmod 1777 /helm
 ENV HELM_REPOSITORY_CONFIG=/helm/repository/repositories.yaml
 ENV HELM_REPOSITORY_CACHE=/helm/cache
 COPY khelm /usr/local/bin/khelmfn
+RUN ln -s khelmfn /usr/local/bin/khelm
 ENTRYPOINT ["/usr/local/bin/khelmfn"]
 
 FROM khelm AS test

--- a/cmd/khelm/fn_test.go
+++ b/cmd/khelm/fn_test.go
@@ -44,13 +44,13 @@ func TestKptFnCommand(t *testing.T) {
 
 	for _, c := range []struct {
 		name           string
-		input          kptFnConfig
+		input          config.KRMFuncConfig
 		mustContainObj int
 		mustContain    []string
 	}{
 		{
 			"chart path only",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "namespace"),
 				},
@@ -59,7 +59,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"latest cluster scoped remote chart",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Repository: "https://charts.jetstack.io",
 					Chart:      "cert-manager",
@@ -69,7 +69,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"remote chart with version",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Repository: "https://charts.jetstack.io",
 					Chart:      "cert-manager",
@@ -80,7 +80,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"release name",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "release-name"),
 				},
@@ -92,7 +92,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"valueFiles",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "values-inheritance", "chart"),
 				},
@@ -103,7 +103,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"values",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "values-inheritance", "chart"),
 				},
@@ -116,7 +116,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"values override",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "values-inheritance", "chart"),
 				},
@@ -130,7 +130,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"apiversions",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "apiversions-condition", "chart"),
 				},
@@ -141,7 +141,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"kubeversion",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "release-name"),
 				},
@@ -152,7 +152,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"expand-list",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "expand-list"),
 				},
@@ -161,7 +161,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"namespace",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "namespace"),
 				},
@@ -173,7 +173,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"force namespace",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "namespace"),
 				},
@@ -185,7 +185,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"exclude",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "namespace"),
 				},
@@ -203,7 +203,7 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"include",
-			kptFnConfig{ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{ChartConfig: config.ChartConfig{
 				LoaderConfig: config.LoaderConfig{
 					Chart: filepath.Join(exampleDir, "namespace"),
 				},
@@ -227,8 +227,8 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"annotate output path",
-			kptFnConfig{
-				ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{
+				ChartConfig: config.ChartConfig{
 					LoaderConfig: config.LoaderConfig{
 						Chart: filepath.Join(exampleDir, "namespace"),
 					},
@@ -239,8 +239,8 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"annotate output path when annotations empty",
-			kptFnConfig{
-				ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{
+				ChartConfig: config.ChartConfig{
 					LoaderConfig: config.LoaderConfig{
 						Chart: filepath.Join(exampleDir, "empty-annotations"),
 					},
@@ -256,8 +256,8 @@ func TestKptFnCommand(t *testing.T) {
 		},
 		{
 			"output kustomization",
-			kptFnConfig{
-				ChartConfig: &config.ChartConfig{
+			config.KRMFuncConfig{
+				ChartConfig: config.ChartConfig{
 					LoaderConfig: config.LoaderConfig{
 						Chart: filepath.Join(exampleDir, "namespace"),
 					},
@@ -282,10 +282,14 @@ func TestKptFnCommand(t *testing.T) {
 			}
 			inputAnnotations[annotationPath] = outPath
 			b, err := yaml.Marshal(map[string]interface{}{
-				"apiVersion":     "config.kubernetes.io/v1alpha1",
-				"kind":           "ResourceList",
-				"items":          inputItems,
-				"functionConfig": map[string]interface{}{"data": c.input},
+				"apiVersion": "config.kubernetes.io/v1alpha1",
+				"kind":       "ResourceList",
+				"items":      inputItems,
+				"functionConfig": config.KRMFuncConfigFile{
+					APIVersion:    "khelm.mgoltzsche.github.com/v2",
+					Kind:          "ChartRenderer",
+					KRMFuncConfig: c.input,
+				},
 			})
 			require.NoError(t, err)
 			var out bytes.Buffer

--- a/cmd/khelm/root.go
+++ b/cmd/khelm/root.go
@@ -60,7 +60,7 @@ func Execute(reader io.Reader, writer io.Writer) error {
 
 	if filepath.Base(os.Args[0]) == "khelmfn" {
 		// Add kpt function command
-		rootCmd = kptFnCommand(h)
+		rootCmd = krmFnCommand(h)
 		rootCmd.SetIn(reader)
 		rootCmd.SetOut(writer)
 		rootCmd.SetErr(&errBuf)

--- a/e2e/kpt-krm-fn-tests.bats
+++ b/e2e/kpt-krm-fn-tests.bats
@@ -10,7 +10,7 @@ teardown() {
 	rm -rf $TMP_DIR
 }
 
-@test "kpt fn should run example/kpt/local-chart" {
+@test "kpt imperative fn should render local-chart" {
 	cd example/kpt/local-chart
 	rm -rf output
 	mkdir output
@@ -19,7 +19,7 @@ teardown() {
 	grep -q jenkins-role-binding ./output/output.yaml
 }
 
-@test "kpt fn should run cache chart dependency" {
+@test "kpt imperative fn should cache chart dependency" {
 	cd example/kpt/local-chart
 	rm -rf output
 	mkdir output
@@ -37,7 +37,7 @@ teardown() {
 	grep -qv myconfiga ./output/output.yaml
 }
 
-@test "kpt fn should run example/kpt/chart-to-kustomization" {
+@test "kpt imperative fn should convert parameterized chart into kustomization" {
 	cd example/kpt/chart-to-kustomization
 	rm -rf output-kustomization
 	make fn
@@ -48,7 +48,7 @@ teardown() {
 	kustomize build ./output-kustomization | grep -q ' myconfiga'
 }
 
-@test "kpt fn should run example/kpt/remote-chart" {
+@test "kpt imperative fn should render remote chart" {
 	cd example/kpt/remote-chart
 	rm -f output-remote.yaml
 	make fn
@@ -57,7 +57,7 @@ teardown() {
 	grep -q cainjector ./output-remote.yaml
 }
 
-@test "kpt fn should cache remote chart" {
+@test "kpt imperative fn should cache remote chart" {
 	cd example/kpt/remote-chart
 	rm -f output-remote.yaml
 	kpt fn eval --as-current-user --network \
@@ -76,4 +76,15 @@ teardown() {
 		--fn-config=./fn-config.yaml .
 	[ -f ./output-remote.yaml ]
 	grep -q cainjector ./output-remote.yaml
+}
+
+@test "kpt declarative fn should render built-in chart" {
+	cd example/kpt/declarative
+	rm -rf generated
+	make render
+
+	[ -f ./generated/kustomization.yaml ]
+	[ -f ./generated/deployment_myrelease-cert-manager.yaml ]
+	grep -q myrelease-cert-manager ./generated/deployment_myrelease-cert-manager.yaml
+	grep -q ' namespace: "mynamespace"' ./generated/deployment_myrelease-cert-manager.yaml
 }

--- a/example/kpt/declarative/.krmignore
+++ b/example/kpt/declarative/.krmignore
@@ -1,0 +1,1 @@
+Chart.yaml

--- a/example/kpt/declarative/Dockerfile
+++ b/example/kpt/declarative/Dockerfile
@@ -1,0 +1,9 @@
+ARG IMAGE=mgoltzsche/khelm
+FROM $IMAGE
+COPY ./chart /chart
+ENV KHELM_BUILTIN_CHART=/chart \
+	KHELM_KIND=GenerateSampleApp \
+	KHELM_APIVERSION=blueprints.example.org/v1alpha1 \
+	KHELM_OUTPUT_PATH=generated/
+# populate cache
+RUN khelm template $KHELM_BUILTIN_CHART >/dev/null && chmod +rx /helm/cache

--- a/example/kpt/declarative/Kptfile
+++ b/example/kpt/declarative/Kptfile
@@ -1,0 +1,10 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: webapp
+info:
+  description: webapp example
+pipeline:
+  mutators:
+  - image: local/declarative-khelm-fn-example:unstable
+    configPath: ./fn-config.yaml

--- a/example/kpt/declarative/Makefile
+++ b/example/kpt/declarative/Makefile
@@ -1,0 +1,7 @@
+IMAGE ?= mgoltzsche/khelm:latest
+
+render: image
+	kpt fn render
+
+image:
+	docker build --force-rm -t local/declarative-khelm-fn-example:unstable --build-arg IMAGE="$(IMAGE)" .

--- a/example/kpt/declarative/chart/Chart.yaml
+++ b/example/kpt/declarative/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+description: example chart
+name: example
+version: 0.1.0
+dependencies:
+- name: cert-manager
+  version: 1.0.2
+  repository: https://charts.jetstack.io

--- a/example/kpt/declarative/fn-config.yaml
+++ b/example/kpt/declarative/fn-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: blueprints.example.org/v1alpha1
+kind: GenerateSampleApp
+metadata:
+  name: myrelease
+  namespace: mynamespace
+  annotations:
+    config.kubernetes.io/local-config: "true"
+# same structure as the generator.yaml within the other examples (except for chart and repository fields)
+values:
+  myproperty: myvalue
+  # defaults to:
+  #outputPath: generated/
+# default:
+#outputPath: generated/

--- a/example/kpt/local-chart/fn-config.yaml
+++ b/example/kpt/local-chart/fn-config.yaml
@@ -1,20 +1,19 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: khelm.mgoltzsche.github.com/v2
+kind: ChartRenderer
 metadata:
   name: render-local-chart
   annotations:
     config.kubernetes.io/local-config: "true"
-data:
-  # same structure as the generator.yaml within the other examples
-  chart: /examples/kpt/local-chart/chart # chart must be mounted here
-  name: myrelease
-  namespace: mynamespace
-  apiVersions:
-  - myfancyapi/v1
-  exclude:
-  - apiVersion: v1
-    kind: ConfigMap
-    name: myconfiga
-  # additional kpt function specific fields
-  outputPath: output.yaml
-  debug: true
+# same structure as the generator.yaml within the other examples
+chart: /examples/kpt/local-chart/chart # chart must be mounted here
+name: myrelease
+namespace: mynamespace
+apiVersions:
+- myfancyapi/v1
+exclude:
+- apiVersion: v1
+  kind: ConfigMap
+  name: myconfiga
+# additional kpt function specific fields
+outputPath: output.yaml
+debug: true

--- a/example/kpt/remote-chart/fn-config.yaml
+++ b/example/kpt/remote-chart/fn-config.yaml
@@ -1,13 +1,12 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: khelm.mgoltzsche.github.com/v2
+kind: ChartRenderer
 metadata:
   name: remote-chart
   annotations:
     config.kubernetes.io/local-config: "true"
-data:
-  repository: https://charts.jetstack.io
-  chart: cert-manager
-  version: 0.9.1
-  name: myrelease
-  outputPath: output-remote.yaml
-  debug: true
+repository: https://charts.jetstack.io
+chart: cert-manager
+version: 0.9.1
+name: myrelease
+outputPath: output-remote.yaml
+debug: true

--- a/example/kustomize-krm/cert-manager/generator.yaml
+++ b/example/kustomize-krm/cert-manager/generator.yaml
@@ -1,3 +1,4 @@
+# TODO: replace deprecated kpt fn config kind (and `data` field with `config`)
 apiVersion: khelm.mgoltzsche.github.com/v2
 kind: ChartRenderer
 metadata:


### PR DESCRIPTION
This is to simplify the definition of a helm chart based declarative manifest generator as part of a kpt-based blueprint.

* Support building krm function images that include khelm, a helm chart and its cached dependencies so that they can be used offline and without file system access.
* Allow to specify a specific apigroup, kind, chart and repo for each function via env vars.