### PR TITLE
fix OCI chart support

### DIFF
--- a/example/oci-dependency/Chart.lock
+++ b/example/oci-dependency/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: karpenter
+  repository: oci://public.ecr.aws/karpenter
+  version: 0.35.0
+digest: sha256:c351689f0d2d254c02b7e8aac54c06fb66e8871dfae3479cfbf1af88e1fee268
+generated: "2024-04-11T01:47:48.41682948+02:00"

--- a/example/oci-dependency/Chart.yaml
+++ b/example/oci-dependency/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+description: example chart with OCI chart as dependency
+name: oci-dependency
+version: 0.0.0
+dependencies:
+- name: karpenter
+  version: "0.35.0"
+  repository: "oci://public.ecr.aws/karpenter"

--- a/example/oci-dependency/generator.yaml
+++ b/example/oci-dependency/generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: khelm.mgoltzsche.github.com/v2
+kind: ChartRenderer
+metadata:
+  name: oci-dependency
+  namespace: kube-system
+chart: .

--- a/example/oci-image/generator.yaml
+++ b/example/oci-image/generator.yaml
@@ -3,5 +3,6 @@ kind: ChartRenderer
 metadata:
   name: karpenter
   namespace: kube-system
-chart: "oci://public.ecr.aws/karpenter/karpenter"
+chart: karpenter
 version: 0.35.0
+repository: "oci://public.ecr.aws/karpenter"

--- a/pkg/helm/load.go
+++ b/pkg/helm/load.go
@@ -230,12 +230,19 @@ func buildLocalCharts(ctx context.Context, localCharts []localChart, cfg *config
 }
 
 func buildChartDependencies(ctx context.Context, chartRequested *chart.Chart, chartPath string, cfg *config.LoaderConfig, repos repositoryConfig, settings *cli.EnvSettings, getters getter.Providers) error {
+	registryClient, err := registry.NewClient(
+		registry.ClientOptEnableCache(true),
+	)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	man := &downloader.Manager{
 		Out:              log.Writer(),
 		ChartPath:        chartPath,
 		Keyring:          cfg.Keyring,
 		SkipUpdate:       true,
 		Getters:          getters,
+		RegistryClient:   registryClient,
 		RepositoryConfig: settings.RepositoryConfig,
 		RepositoryCache:  settings.RepositoryCache,
 		Debug:            settings.Debug,
@@ -244,7 +251,7 @@ func buildChartDependencies(ctx context.Context, chartRequested *chart.Chart, ch
 		man.Verify = downloader.VerifyAlways
 	}
 	// Workaround for leftover tmpcharts dir (which makes Build() fail)
-	err := os.RemoveAll(filepath.Join(chartPath, "tmpcharts"))
+	err = os.RemoveAll(filepath.Join(chartPath, "tmpcharts"))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/helm/load.go
+++ b/pkg/helm/load.go
@@ -38,6 +38,10 @@ func (h *Helm) loadChart(ctx context.Context, cfg *config.ChartConfig) (*chart.C
 		} else {
 			return nil, errors.Errorf("chart directory %q not found and no repository specified", cfg.Chart)
 		}
+	} else if registry.IsOCI(cfg.Repository) {
+		cfg.Chart = fmt.Sprintf("%s/%s", cfg.Repository, cfg.Chart)
+		cfg.Repository = ""
+		return h.loadOCIChart(ctx, cfg)
 	}
 	return h.loadRemoteChart(ctx, cfg)
 }

--- a/pkg/helm/render_test.go
+++ b/pkg/helm/render_test.go
@@ -55,6 +55,8 @@ func TestRender(t *testing.T) {
 		{"include", "example/include/generator.yaml", []string{}, "  key: b", nil},
 		{"local-chart-with-local-dependency-and-transitive-remote", "example/localrefref/generator.yaml", []string{}, "rook-ceph-v0.9.3", nil},
 		{"local-chart-with-remote-dependency", "example/localref/generator.yaml", []string{}, "rook-ceph-v0.9.3", nil},
+		{"oci-chart", "example/oci-image/generator.yaml", []string{"kube-system", "kube-node-lease"}, "name: ec2nodeclasses.karpenter.k8s.aws", nil},
+		{"oci-dependency", "example/oci-dependency/generator.yaml", []string{"kube-system", "kube-node-lease"}, "name: ec2nodeclasses.karpenter.k8s.aws", nil},
 		{"values-inheritance", "example/values-inheritance/generator.yaml", []string{}, " inherited: inherited value\n  fileoverwrite: overwritten by file\n  valueoverwrite: overwritten by generator config", nil},
 		{"cluster-scoped", "example/cluster-scoped/generator.yaml", []string{}, "myrolebinding", nil},
 		{"chart-hooks", "example/chart-hooks/generator.yaml", []string{"default"}, "  key: myvalue", []string{


### PR DESCRIPTION
* Closes #74: Support OCI chart dependencies (OCI repository URI within `repository` field of the `Chart.yaml`).
* Relates to #46 and #72: Support specifying an OCI repository URI within the `repository` field of the kustomize plugin or kpt function config.